### PR TITLE
Feat/spin

### DIFF
--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -18,18 +18,6 @@ const globe = new WebGlGlobe(document.body, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-let rot = 180;
-let spinning = true;
+globe.startAutoSpin(0.01);
 
-(function spin() {
-  rot += 0.1;
-  const lng = (rot % 360) - 180;
-  globe.setProps({cameraView: {lng, lat: 10, altitude: distance}});
-
-  if (spinning) {
-    requestAnimationFrame(spin);
-  }
-})();
-
-document.body.addEventListener('mousedown', () => (spinning = false));
-document.body.addEventListener('mousewheel', () => (spinning = false));
+setTimeout(() => {globe.stopAutoSpin()}, 1000);

--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -18,7 +18,7 @@ const globe = new WebGlGlobe(document.body, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-globe.startAutoSpin(0.1, true);
+globe.enableAutoSpin(1, true);
 
 setTimeout(() => {
   globe.stopAutoSpin();

--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -18,6 +18,6 @@ const globe = new WebGlGlobe(document.body, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-globe.startAutoSpin(0.01);
+globe.startAutoSpin(0.1, true);
 
-setTimeout(() => {globe.stopAutoSpin()}, 1000);
+setTimeout(() => {globe.stopAutoSpin()}, 5000);

--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -18,10 +18,9 @@ const globe = new WebGlGlobe(document.body, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-globe.setControlsInteractionEnabled(false);
-globe.enableAutoSpin(1);
+globe.setControlsInteractionEnabled( true );
+globe.startAutoSpin(1);
 
 setTimeout(() => {
   globe.stopAutoSpin();
-  globe.setControlsInteractionEnabled(true);
-}, 5000);
+}, 2000);

--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -18,8 +18,10 @@ const globe = new WebGlGlobe(document.body, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-globe.enableAutoSpin(1, true);
+globe.setControlsInteractionEnabled(false);
+globe.enableAutoSpin(1);
 
 setTimeout(() => {
   globe.stopAutoSpin();
+  globe.setControlsInteractionEnabled(true);
 }, 5000);

--- a/examples/spinning/main.ts
+++ b/examples/spinning/main.ts
@@ -20,4 +20,6 @@ const globe = new WebGlGlobe(document.body, {
 
 globe.startAutoSpin(0.1, true);
 
-setTimeout(() => {globe.stopAutoSpin()}, 5000);
+setTimeout(() => {
+  globe.stopAutoSpin();
+}, 5000);

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -1,0 +1,56 @@
+// @ts-ignore
+import {orbitcontrols} from './vendor/orbit-controls.js';
+
+export class InteractionController {
+  private globeControls: OrbitControls;
+  private container: HTMLElement;
+  private controlsInteractionEnabled = false;
+  private spinAbortController: AbortController | null = null;
+
+  constructor(globeControls: OrbitControls, container: HTMLElement) {
+    this.globeControls = globeControls;
+    this.container = container;
+
+    this.globeControls.enabled = true;
+  }
+
+  public setAutoSpin(isEnabled: boolean, speed: number = 1): void {
+    this.abortCurrentSpin();
+
+    this.globeControls.autoRotate = isEnabled;
+    this.globeControls.autoRotateSpeed = speed;
+
+    if (isEnabled && this.controlsInteractionEnabled) {
+      this.spinAbortController = new AbortController();
+      const stopAutoSpin = () => this.setAutoSpin(false);
+
+      const options = { once: true, signal: this.spinAbortController.signal };
+      this.container.addEventListener('mousedown', stopAutoSpin, options);
+      this.container.addEventListener('wheel', stopAutoSpin, options);
+      this.container.addEventListener('touchstart', stopAutoSpin, options);
+    }
+  }
+
+  public setControlsInteractionEnabled(enabled: boolean): void {
+    this.controlsInteractionEnabled = enabled;
+    this.updateControlsEnabled(enabled);
+
+    if (enabled) {
+      this.setAutoSpin(false);
+    }
+  }
+
+  private abortCurrentSpin(): void {
+    if (this.spinAbortController) {
+      this.spinAbortController.abort();
+      this.spinAbortController = null;
+    }
+  }
+
+  private updateControlsEnabled(isEnabled: boolean): void {
+    this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
+  }
+}
+
+
+

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import {orbitcontrols} from './vendor/orbit-controls.js';
+import {OrbitControls} from './vendor/orbit-controls.js';
 
 export class InteractionController {
   private globeControls: OrbitControls;

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -11,7 +11,8 @@ export class InteractionController {
     this.globeControls = globeControls;
     this.container = container;
 
-    this.globeControls.enabled = true;
+    // Disable the default controls interaction
+    this.updateControlsEnabled(false);
   }
 
   public setAutoSpin(isEnabled: boolean, speed: number = 1): void {
@@ -24,7 +25,7 @@ export class InteractionController {
       this.spinAbortController = new AbortController();
       const stopAutoSpin = () => this.setAutoSpin(false);
 
-      const options = { once: true, signal: this.spinAbortController.signal };
+      const options = {once: true, signal: this.spinAbortController.signal};
       this.container.addEventListener('mousedown', stopAutoSpin, options);
       this.container.addEventListener('wheel', stopAutoSpin, options);
       this.container.addEventListener('touchstart', stopAutoSpin, options);
@@ -48,9 +49,8 @@ export class InteractionController {
   }
 
   private updateControlsEnabled(isEnabled: boolean): void {
+    // Enable or disable the controls by setting the pointer events CSS property
+    // If we disable the controls, the Three.js autoRoate does not work
     this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
   }
 }
-
-
-

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -33,9 +33,7 @@ export class Renderer extends EventTarget {
 
   private rendererSize: Vector2 = new Vector2();
   private atmosphere: Atmosphere = new Atmosphere();
-  private controlsInteractionEnabled = true;
   private clock = new Clock();
-  private spinAbortController: AbortController | null = null;
 
   constructor(container?: HTMLElement) {
     super();
@@ -72,6 +70,10 @@ export class Renderer extends EventTarget {
 
     const {width, height} = this.container.getBoundingClientRect();
     this.resize(width, height);
+  }
+
+  getGlobeControls(): OrbitControls {
+    return this.globeControls;
   }
 
   getRenderMode() {
@@ -117,25 +119,6 @@ export class Renderer extends EventTarget {
     return this.mapCamera;
   }
 
-  setAutoSpin(isEnabled: boolean, speed?: number): void {
-    if (this.spinAbortController) {
-      this.spinAbortController.abort();
-      this.spinAbortController = null;
-    }
-
-    this.globeControls.spinning(isEnabled, speed);
-
-    if (isEnabled && this.controlsInteractionEnabled) {
-      this.spinAbortController = new AbortController();
-      const stopAutoSpin = () => this.setAutoSpin(false);
-
-      const options = {once: true, signal: this.spinAbortController.signal};
-      this.container.addEventListener('mousedown', stopAutoSpin, options);
-      this.container.addEventListener('wheel', stopAutoSpin, options);
-      this.container.addEventListener('touchstart', stopAutoSpin, options);
-    }
-  }
-
   setCameraView(cameraView: CameraView) {
     if (cameraView === this.cameraView) {
       return;
@@ -178,11 +161,6 @@ export class Renderer extends EventTarget {
       // otherwise create the marker
       this.markersById[props.id] = new MarkerHtml(this, props);
     }
-  }
-
-  public setControlsInteractionEnabled(enabled: boolean) {
-    this.controlsInteractionEnabled = enabled;
-    this.updateControlsEnabled();
   }
 
   destroy() {
@@ -274,14 +252,6 @@ export class Renderer extends EventTarget {
 
     this.globeControls.enabled = this.renderMode === RenderMode.GLOBE;
     this.mapControls.enabled = this.renderMode === RenderMode.MAP;
-  }
-
-  private updateControlsEnabled() {
-    if (this.controlsInteractionEnabled) {
-      this.globeControls.connect();
-    } else {
-      this.globeControls.disconnect();
-    }
   }
 
   private animationLoopUpdate() {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -136,21 +136,6 @@ export class Renderer extends EventTarget {
     }
   }
 
-  getCameraView(): CameraView | undefined {
-    if (this.renderMode === RenderMode.GLOBE) {
-      return globePositionToCameraView(this.globeCamera.position);
-    } else if (this.renderMode === RenderMode.MAP) {
-      return {
-        renderMode: RenderMode.MAP,
-        lat: this.mapCamera.position.y * 90,
-        lng: this.mapCamera.position.x * 90,
-        zoom: this.mapCamera.zoom,
-        altitude: 0
-      };
-    }
-    return undefined;
-  }
-
   setCameraView(cameraView: CameraView) {
     if (cameraView === this.cameraView) {
       return;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -117,7 +117,7 @@ export class Renderer extends EventTarget {
     return this.mapCamera;
   }
 
-  setAutoSpin(isEnabled: boolean, speed?: number, enableInteraction?: boolean): void {
+  setAutoSpin(isEnabled: boolean, speed?: number): void {
     if (this.spinAbortController) {
       this.spinAbortController.abort();
       this.spinAbortController = null;
@@ -125,24 +125,14 @@ export class Renderer extends EventTarget {
 
     this.globeControls.spinning(isEnabled, speed);
 
-    if (isEnabled) {
-      const interaction = enableInteraction ?? true;
+    if (isEnabled && this.controlsInteractionEnabled) {
+      this.spinAbortController = new AbortController();
       const stopAutoSpin = () => this.setAutoSpin(false);
 
-      if (interaction) {
-        this.setControlsInteractionEnabled(true);
-        this.spinAbortController = new AbortController(); // Ensure the AbortController is instantiated
-
-        const options = {once: true, signal: this.spinAbortController.signal};
-
-        this.container.addEventListener('mousedown', stopAutoSpin, options);
-        this.container.addEventListener('wheel', stopAutoSpin, options);
-        this.container.addEventListener('touchstart', stopAutoSpin, options);
-      } else {
-        this.setControlsInteractionEnabled(false);
-      }
-    } else {
-      this.setControlsInteractionEnabled(true);
+      const options = {once: true, signal: this.spinAbortController.signal};
+      this.container.addEventListener('mousedown', stopAutoSpin, options);
+      this.container.addEventListener('wheel', stopAutoSpin, options);
+      this.container.addEventListener('touchstart', stopAutoSpin, options);
     }
   }
 
@@ -204,7 +194,7 @@ export class Renderer extends EventTarget {
       this.markersById[props.id] = new MarkerHtml(this, props);
     }
   }
-  setControlsInteractionEnabled(enabled: boolean) {
+  public setControlsInteractionEnabled(enabled: boolean) {
     this.controlsInteractionEnabled = enabled;
     this.updateControlsEnabled();
   }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -50,7 +50,7 @@ export class Renderer extends EventTarget {
     renderer.setClearColor(0xffffff, 0);
     renderer.setAnimationLoop(this.animationLoopUpdate.bind(this));
 
-    // Set the pixel ratio to the minimum of the device's pixel ratio or 2, for optimal rendering performance
+    // for rendering performance, we don't use a pixel-ratio above 2
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
     this.webglRenderer = renderer;
@@ -179,6 +179,7 @@ export class Renderer extends EventTarget {
       this.markersById[props.id] = new MarkerHtml(this, props);
     }
   }
+
   public setControlsInteractionEnabled(enabled: boolean) {
     this.controlsInteractionEnabled = enabled;
     this.updateControlsEnabled();

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -46,6 +46,8 @@ export class Renderer extends EventTarget {
     });
     renderer.setClearColor(0xffffff, 0);
     renderer.setAnimationLoop(this.animationLoopUpdate.bind(this));
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
     this.webglRenderer = renderer;
 
     this.container.appendChild(this.webglRenderer.domElement);
@@ -108,6 +110,21 @@ export class Renderer extends EventTarget {
     if (this.renderMode === RenderMode.GLOBE) return this.globeCamera;
 
     return this.mapCamera;
+  }
+
+  getCameraView(): CameraView | undefined {
+    if (this.renderMode === RenderMode.GLOBE) {
+      return globePositionToCameraView(this.globeCamera.position);
+    } else if (this.renderMode === RenderMode.MAP) {
+      return {
+        renderMode: RenderMode.MAP,
+        lat: this.mapCamera.position.y * 90,
+        lng: this.mapCamera.position.x * 90,
+        zoom: this.mapCamera.zoom,
+        altitude: 0
+      };
+    }
+    return undefined;
   }
 
   setCameraView(cameraView: CameraView) {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -173,7 +173,7 @@ export class Renderer extends EventTarget {
       this.markersById[props.id] = new MarkerHtml(this, props);
     }
   }
-  setcontrolsinteractionenabled(enabled: boolean) {
+  setControlsInteractionEnabled(enabled: boolean) {
     this.controlsInteractionEnabled = enabled;
     this.updateControlsEnabled();
   }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -279,7 +279,7 @@ export class Renderer extends EventTarget {
     if (this.controlsInteractionEnabled) {
       this.globeControls.connect();
     } else {
-      this.globeControls.dispose();
+      this.globeControls.disconnect();
     }
   }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,4 +1,4 @@
-import {OrthographicCamera, PerspectiveCamera, Scene, Vector2, WebGLRenderer} from 'three';
+import { OrthographicCamera, PerspectiveCamera, Scene, Vector2, WebGLRenderer } from 'three';
 
 // @ts-ignore
 import {OrbitControls} from './vendor/orbit-controls.js';
@@ -33,6 +33,7 @@ export class Renderer extends EventTarget {
 
   private rendererSize: Vector2 = new Vector2();
   private atmosphere: Atmosphere = new Atmosphere();
+  private controlsInteractionEnabled = true;
 
   constructor(container?: HTMLElement) {
     super();
@@ -46,6 +47,8 @@ export class Renderer extends EventTarget {
     });
     renderer.setClearColor(0xffffff, 0);
     renderer.setAnimationLoop(this.animationLoopUpdate.bind(this));
+
+    // Set the pixel ratio to the minimum of the device's pixel ratio or 2, for optimal rendering performance
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
     this.webglRenderer = renderer;
@@ -170,6 +173,10 @@ export class Renderer extends EventTarget {
       this.markersById[props.id] = new MarkerHtml(this, props);
     }
   }
+  setcontrolsinteractionenabled(enabled: boolean) {
+    this.controlsInteractionEnabled = enabled;
+    this.updateControlsEnabled();
+  }
 
   destroy() {
     this.webglRenderer.dispose();
@@ -234,6 +241,7 @@ export class Renderer extends EventTarget {
       this.dispatchEvent(event);
     });
 
+
     const origUpdate = this.mapControls.update.bind(this.mapControls);
 
     // override the update-function to limit map bounds
@@ -260,6 +268,14 @@ export class Renderer extends EventTarget {
 
     this.globeControls.enabled = this.renderMode === RenderMode.GLOBE;
     this.mapControls.enabled = this.renderMode === RenderMode.MAP;
+  }
+
+  private updateControlsEnabled() {
+    if (this.controlsInteractionEnabled) {
+      this.globeControls.connect();
+    } else {
+      this.globeControls.dispose();
+    }
   }
 
   private animationLoopUpdate() {

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -96,6 +96,9 @@ class OrbitControls extends EventDispatcher {
     // the target DOM element for key events
     this._domElementKeyEvents = null;
 
+    // track if listeners have been attached
+    this._listenersAttached = false;
+
     //
     // public methods
     //
@@ -261,12 +264,29 @@ class OrbitControls extends EventDispatcher {
       };
     })();
 
-    this.dispose = function () {
+    this.connect = function() {
+      if (scope._listenersAttached === true) return;
+
+      scope.domElement.addEventListener('contextmenu', onContextMenu);
+      scope.domElement.addEventListener('pointerdown', onPointerDown);
+      scope.domElement.addEventListener('pointercancel', onPointerCancel);
+      scope.domElement.addEventListener('wheel', onMouseWheel, { passive: false });
+      scope.domElement.addEventListener('pointermove', onMouseMove);
+
+      if (scope._domElementKeyEvents !== null) {
+        scope._domElementKeyEvents.addEventListener('keydown', onKeyDown);
+      }
+
+      scope._listenersAttached = true;
+    };
+
+    this.dispose = function() {
       scope.domElement.removeEventListener('contextmenu', onContextMenu);
 
       scope.domElement.removeEventListener('pointerdown', onPointerDown);
       scope.domElement.removeEventListener('pointercancel', onPointerCancel);
       scope.domElement.removeEventListener('wheel', onMouseWheel);
+      scope.domElement.removeEventListener('pointermove', onMouseMove);
 
       scope.domElement.removeEventListener('pointermove', onPointerMove);
       scope.domElement.removeEventListener('pointerup', onPointerUp);
@@ -275,6 +295,7 @@ class OrbitControls extends EventDispatcher {
         scope._domElementKeyEvents.removeEventListener('keydown', onKeyDown);
       }
 
+      scope._listenersAttached = false;
       //scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
     };
 

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -139,11 +139,6 @@ class OrbitControls extends EventDispatcher {
       state = STATE.NONE;
     };
 
-    this.spinning = function (isAutoRotating, autoRotateSpeed) {
-      scope.autoRotate = isAutoRotating;
-      scope.autoRotateSpeed = autoRotateSpeed || scope.autoRotateSpeed;
-    };
-
     // this method is exposed, but perhaps it would be better if we can make it private...
     this.update = (function () {
       const offset = new Vector3();

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -285,7 +285,7 @@ class OrbitControls extends EventDispatcher {
 
       scope.domElement.removeEventListener('pointerdown', onPointerDown);
       scope.domElement.removeEventListener('pointercancel', onPointerCancel);
-      scope.domElement.removeEventListener('wheel', onMouseWheel);
+      scope.domElement.removeEventListener('wheel', onMouseWheel, {passive: false});
       scope.domElement.removeEventListener('pointermove', onMouseMove);
 
       scope.domElement.removeEventListener('pointermove', onPointerMove);

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -264,13 +264,13 @@ class OrbitControls extends EventDispatcher {
       };
     })();
 
-    this.connect = function() {
+    this.connect = function () {
       if (scope._listenersAttached === true) return;
 
       scope.domElement.addEventListener('contextmenu', onContextMenu);
       scope.domElement.addEventListener('pointerdown', onPointerDown);
       scope.domElement.addEventListener('pointercancel', onPointerCancel);
-      scope.domElement.addEventListener('wheel', onMouseWheel, { passive: false });
+      scope.domElement.addEventListener('wheel', onMouseWheel, {passive: false});
       scope.domElement.addEventListener('pointermove', onMouseMove);
 
       if (scope._domElementKeyEvents !== null) {
@@ -280,7 +280,7 @@ class OrbitControls extends EventDispatcher {
       scope._listenersAttached = true;
     };
 
-    this.dispose = function() {
+    this.dispose = function () {
       scope.domElement.removeEventListener('contextmenu', onContextMenu);
 
       scope.domElement.removeEventListener('pointerdown', onPointerDown);
@@ -1093,17 +1093,9 @@ class OrbitControls extends EventDispatcher {
       return pointerPositions[pointer.pointerId];
     }
 
-    //
-
-    scope.domElement.addEventListener('contextmenu', onContextMenu);
-
-    scope.domElement.addEventListener('pointerdown', onPointerDown);
-    scope.domElement.addEventListener('pointercancel', onPointerCancel);
-    scope.domElement.addEventListener('wheel', onMouseWheel, {passive: false});
-    scope.domElement.addEventListener('pointermove', onMouseMove);
-
     // force an update at start
 
+    this.connect();
     this.update();
   }
 }

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -285,7 +285,7 @@ class OrbitControls extends EventDispatcher {
       scope._listenersAttached = true;
     };
 
-    this.dispose = function () {
+    this.disconnect = function () {
       scope.domElement.removeEventListener('contextmenu', onContextMenu);
 
       scope.domElement.removeEventListener('pointerdown', onPointerDown);

--- a/src/renderer/vendor/orbit-controls.js
+++ b/src/renderer/vendor/orbit-controls.js
@@ -139,6 +139,11 @@ class OrbitControls extends EventDispatcher {
       state = STATE.NONE;
     };
 
+    this.spinning = function (isAutoRotating, autoRotateSpeed) {
+      scope.autoRotate = isAutoRotating;
+      scope.autoRotateSpeed = autoRotateSpeed || scope.autoRotateSpeed;
+    };
+
     // this method is exposed, but perhaps it would be better if we can make it private...
     this.update = (function () {
       const offset = new Vector3();

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -133,7 +133,7 @@ export class WebGlGlobe extends EventTarget {
     const stopAutoSpin = () => this.stopAutoSpin();
 
     if (enableInteraction) {
-      const options = { once: true, signal: this.spinAbortController.signal };
+      const options = {once: true, signal: this.spinAbortController.signal};
       this.container.addEventListener('mousedown', stopAutoSpin, options);
       this.container.addEventListener('wheel', stopAutoSpin, options);
       this.container.addEventListener('touchstart', stopAutoSpin, options);
@@ -141,15 +141,21 @@ export class WebGlGlobe extends EventTarget {
       this.renderer.setcontrolsinteractionenabled(false);
     }
 
-    let rot = 180;
-
     const cameraView = this.renderer.getCameraView();
+
+    if (!cameraView) {
+      console.error('Cannot start auto-spin: camera view is not available.');
+      return;
+    }
+
+    let rot = cameraView.lng + 180;
     const spin = () => {
       rot += speed;
       const lng = (rot % 360) - 180;
-      this.setProps({ cameraView: { ...cameraView, lng } });
+      this.setProps({cameraView: {...cameraView, lng}});
       this.spinRequestAnimationFrameId = requestAnimationFrame(spin);
     };
+
     this.spinRequestAnimationFrameId = requestAnimationFrame(spin);
   }
 
@@ -257,7 +263,7 @@ export class WebGlGlobe extends EventTarget {
         });
         this.dispatchEvent(newEvent);
       },
-      { signal: this.abortController.signal }
+      {signal: this.abortController.signal}
     );
   }
 
@@ -287,7 +293,7 @@ export class WebGlGlobe extends EventTarget {
 
 export interface WebGlGlobeEventMap {
   cameraViewChanged: CustomEvent<CameraView>;
-  layerLoadingStateChanged: CustomEvent<{ layer: LayerProps; state: LayerLoadingState }>;
+  layerLoadingStateChanged: CustomEvent<{layer: LayerProps; state: LayerLoadingState}>;
 }
 
 export interface WebGlGlobe {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -120,12 +120,16 @@ export class WebGlGlobe extends EventTarget {
     cancelAnimationFrame(this.tileUpdateRafId);
   }
 
-  public enableAutoSpin(speed: number = 0.1, enableInteraction: boolean = false) {
-    this.renderer.setAutoSpin(true, speed, enableInteraction);
+  public enableAutoSpin(speed: number = 0.1) {
+    this.renderer.setAutoSpin(true, speed);
   }
 
   public stopAutoSpin() {
     this.renderer.setAutoSpin(false);
+  }
+
+  public setControlsInteractionEnabled(enabled: boolean) {
+    this.renderer.setControlsInteractionEnabled(enabled);
   }
 
   private setLayers(layers: LayerProps[]) {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -235,6 +235,7 @@ export class WebGlGlobe extends EventTarget {
     this.resizeObserver.unobserve(this.container);
     this.abortController.abort();
     this.renderer.destroy();
+    this.renderer.getGlobeControls().disconnect()
     void this.tileSelector.destroy();
   }
 

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -4,6 +4,7 @@ import {Layer} from './loader/layer';
 import {RenderTile} from './renderer/types/tile';
 import {TileSelector} from './tile-selector/tile-selector';
 import {Renderer} from './renderer/renderer';
+import {InteractionController} from './renderer/interaction-controller';
 import {RenderMode, RenderOptions} from './renderer/types/renderer';
 import {LayerLoadingState} from './loader/types/layer';
 
@@ -32,6 +33,7 @@ export class WebGlGlobe extends EventTarget {
   private readonly scheduler: RequestScheduler<RenderTile>;
   private readonly renderer: Renderer;
   private readonly tileSelector: TileSelector;
+  private readonly interactionController: InteractionController;
   private abortController: AbortController;
 
   private layersById: Record<string, Layer> = {};
@@ -70,6 +72,11 @@ export class WebGlGlobe extends EventTarget {
     this.tileSelector = new TileSelector({
       workerUrl: WebGlGlobe.tileSelectorWorkerUrl
     });
+
+    this.interactionController = new InteractionController(
+      this.renderer.getGlobeControls(),
+      this.container
+    );
 
     this.setProps({...DEFAULT_PROPS, ...props});
 
@@ -120,16 +127,16 @@ export class WebGlGlobe extends EventTarget {
     cancelAnimationFrame(this.tileUpdateRafId);
   }
 
-  public enableAutoSpin(speed: number = 0.1) {
-    this.renderer.setAutoSpin(true, speed);
+  public startAutoSpin(speed: number = 0.1) {
+    this.interactionController.setAutoSpin(true, speed);
   }
 
   public stopAutoSpin() {
-    this.renderer.setAutoSpin(false);
+    this.interactionController.setAutoSpin(false);
   }
 
   public setControlsInteractionEnabled(enabled: boolean) {
-    this.renderer.setControlsInteractionEnabled(enabled);
+    this.interactionController.setControlsInteractionEnabled(enabled);
   }
 
   private setLayers(layers: LayerProps[]) {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -138,7 +138,7 @@ export class WebGlGlobe extends EventTarget {
       this.container.addEventListener('wheel', stopAutoSpin, options);
       this.container.addEventListener('touchstart', stopAutoSpin, options);
     } else {
-      this.renderer.setcontrolsinteractionenabled(false);
+      this.renderer.setControlsInteractionEnabled(false);
     }
 
     const cameraView = this.renderer.getCameraView();
@@ -167,7 +167,7 @@ export class WebGlGlobe extends EventTarget {
     cancelAnimationFrame(this.spinRequestAnimationFrameId);
 
     // make sure controls are enabled
-    this.renderer.setcontrolsinteractionenabled(true);
+    this.renderer.setControlsInteractionEnabled(true);
     this.spinRequestAnimationFrameId = 0;
 
     if (this.spinAbortController) {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -120,60 +120,12 @@ export class WebGlGlobe extends EventTarget {
     cancelAnimationFrame(this.tileUpdateRafId);
   }
 
-  private spinAbortController: AbortController | null = null;
-
-  private spinRequestAnimationFrameId: number = 0;
-
-  public startAutoSpin(speed: number = 0.1, enableInteraction: boolean = false) {
-    if (this.spinRequestAnimationFrameId) {
-      return;
-    }
-
-    this.spinAbortController = new AbortController();
-    const stopAutoSpin = () => this.stopAutoSpin();
-
-    if (enableInteraction) {
-      const options = {once: true, signal: this.spinAbortController.signal};
-      this.container.addEventListener('mousedown', stopAutoSpin, options);
-      this.container.addEventListener('wheel', stopAutoSpin, options);
-      this.container.addEventListener('touchstart', stopAutoSpin, options);
-    } else {
-      this.renderer.setControlsInteractionEnabled(false);
-    }
-
-    const cameraView = this.renderer.getCameraView();
-
-    if (!cameraView) {
-      console.error('Cannot start auto-spin: camera view is not available.');
-      return;
-    }
-
-    let rot = cameraView.lng + 180;
-    const spin = () => {
-      rot += speed;
-      const lng = (rot % 360) - 180;
-      this.setProps({cameraView: {...cameraView, lng}});
-      this.spinRequestAnimationFrameId = requestAnimationFrame(spin);
-    };
-
-    this.spinRequestAnimationFrameId = requestAnimationFrame(spin);
+  public enableAutoSpin(speed: number = 0.1, enableInteraction: boolean = false) {
+    this.renderer.setAutoSpin(true, speed, enableInteraction);
   }
 
   public stopAutoSpin() {
-    if (!this.spinRequestAnimationFrameId) {
-      return;
-    }
-
-    cancelAnimationFrame(this.spinRequestAnimationFrameId);
-
-    // make sure controls are enabled
-    this.renderer.setControlsInteractionEnabled(true);
-    this.spinRequestAnimationFrameId = 0;
-
-    if (this.spinAbortController) {
-      this.spinAbortController.abort();
-      this.spinAbortController = null;
-    }
+    this.renderer.setAutoSpin(false);
   }
 
   private setLayers(layers: LayerProps[]) {


### PR DESCRIPTION
**Summary**
This PR adds support for auto-spinning the globe, based on updated requirements from the revised story concept.

**Changes**
Implemented startAutoSpin() and stopAutoSpin() methods for controlling the globe’s automatic rotation.
Introduced setPixelRatio() to prevent blurry edges during spinning.

**Context**
The globe is now expected to spin continuously as part of the narrative flow. This behavior is encapsulated within the globe module to allow controlled activation and deactivation.

Requirements
Auto-spin must be "toggleable" via the public API.

It should be configurable whether user interactions stop the auto-spin or are ignored.