### PR TITLE
Feat/fly camera to

### DIFF
--- a/examples/camera-fly-to/index.html
+++ b/examples/camera-fly-to/index.html
@@ -8,7 +8,7 @@
   </head>
 
   <body>
-    <div id="info">Globe with initial spin.</div>
+    <div id="info">Click Button to trigger cameraFlyTo</div>
     <button id="fly-to">Trigger FlyTo</button>
     <div id="globe" style="height: 100vh; width: 100vw"></div>
     <script type="module" src="main.ts"></script>

--- a/examples/camera-fly-to/index.html
+++ b/examples/camera-fly-to/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Example Layer</title>
+  </head>
+
+  <body>
+    <div id="info">Globe with initial spin.</div>
+    <button id="fly-to">Trigger FlyTo</button>
+    <div id="globe" style="height: 100vh; width: 100vw"></div>
+    <script type="module" src="main.ts"></script>
+  </body>
+</html>

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -18,21 +18,15 @@ const globe = new WebGlGlobe(document.getElementById('globe')!, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
-globe.startAutoSpin(0.1, true);
-
 const flyToButton = document.getElementById('fly-to')!;
 
 flyToButton.addEventListener('click', () => {
   globe.setProps({
-    cameraFlyTo: {
+    cameraView: {
       lng: Math.random() * 360 - 180,
       lat: Math.random() * 180 - 90,
       altitude: Math.random() * 20_000_000 + 2_000_000,
-      duration: 2000,
-      onAfterFly: () => {
-        globe.startAutoSpin(0.1, true);
-        console.log('Fly to completed');
-      }
+      interpolationFactor: 0.01 // Example: set a custom interpolation factor
     }
   });
 });

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -18,6 +18,8 @@ const globe = new WebGlGlobe(document.getElementById('globe')!, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
+// globe.startAutoSpin(1)
+globe.setControlsInteractionEnabled(true)
 const flyToButton = document.getElementById('fly-to')!;
 
 flyToButton.addEventListener('click', () => {

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -1,0 +1,31 @@
+import '../style.css';
+
+import {WebGlGlobe, LayerProps} from '../../src';
+
+const distance = 20_000_000;
+
+const globe = new WebGlGlobe(document.getElementById('globe')!, {
+  layers: [
+    {
+      id: 'basemap',
+      zIndex: 0,
+      maxZoom: 5,
+      urlParameters: {},
+      getUrl: ({x, y, zoom}) =>
+        `https://storage.googleapis.com/esa-cfs-tiles/1.9.0/basemaps/colored/${zoom}/${x}/${y}.png`
+    } as LayerProps<{}>
+  ],
+  cameraView: {lng: 0, lat: 0, altitude: distance}
+});
+
+const flyToButton = document.getElementById('fly-to')!;
+
+flyToButton.addEventListener('click', () => {
+  globe.setProps({
+    cameraFlyTo: {
+      lng: Math.random() * 360 - 180,
+      lat: Math.random() * 180 - 90,
+      altitude: Math.random() * 20_000_000 + 2_000_000
+    }
+  });
+});

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -18,6 +18,8 @@ const globe = new WebGlGlobe(document.getElementById('globe')!, {
   cameraView: {lng: 0, lat: 0, altitude: distance}
 });
 
+globe.startAutoSpin(0.1, true);
+
 const flyToButton = document.getElementById('fly-to')!;
 
 flyToButton.addEventListener('click', () => {
@@ -25,7 +27,9 @@ flyToButton.addEventListener('click', () => {
     cameraFlyTo: {
       lng: Math.random() * 360 - 180,
       lat: Math.random() * 180 - 90,
-      altitude: Math.random() * 20_000_000 + 2_000_000
+      altitude: Math.random() * 20_000_000 + 2_000_000,
+      duration: 2000,
+      onAfterFly: () => {console.log('Fly to completed');}
     }
   });
 });

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -29,7 +29,10 @@ flyToButton.addEventListener('click', () => {
       lat: Math.random() * 180 - 90,
       altitude: Math.random() * 20_000_000 + 2_000_000,
       duration: 2000,
-      onAfterFly: () => {console.log('Fly to completed');}
+      onAfterFly: () => {
+        globe.startAutoSpin(0.1, false);
+        console.log('Fly to completed');
+      }
     }
   });
 });

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -22,6 +22,10 @@ const globe = new WebGlGlobe(document.getElementById('globe')!, {
 globe.setControlsInteractionEnabled(true)
 const flyToButton = document.getElementById('fly-to')!;
 
+globe.addEventListener('cameraViewChanged', (event: CustomEventInit) => {
+  console.log('camerachanged', event);
+});
+
 flyToButton.addEventListener('click', () => {
   globe.setProps({
     cameraView: {

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -26,7 +26,7 @@ flyToButton.addEventListener('click', () => {
       lng: Math.random() * 360 - 180,
       lat: Math.random() * 180 - 90,
       altitude: Math.random() * 20_000_000 + 2_000_000,
-      interpolationFactor: 0.01 // Example: set a custom interpolation factor
+      interpolationFactor: 0.1 // Example: set a custom interpolation factor
     }
   });
 });

--- a/examples/camera-fly-to/main.ts
+++ b/examples/camera-fly-to/main.ts
@@ -30,7 +30,7 @@ flyToButton.addEventListener('click', () => {
       altitude: Math.random() * 20_000_000 + 2_000_000,
       duration: 2000,
       onAfterFly: () => {
-        globe.startAutoSpin(0.1, false);
+        globe.startAutoSpin(0.1, true);
         console.log('Fly to completed');
       }
     }

--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
       <li>
         <a href="./examples/synced/index.html">Synced</a>
       </li>
+      <li>
+        <a href="./examples/camera-fly-to/index.html">Camera Fly To</a>
+      </li>
     </ul>
     <div></div>
   </body>

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -1,15 +1,26 @@
 // @ts-ignore
 import {OrbitControls} from './vendor/orbit-controls.js';
+import {CameraView} from './types/camera-view.js';
+import {RenderMode} from './types/renderer';
+import {Renderer} from './renderer';
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
 
 export class InteractionController {
   private globeControls: OrbitControls;
   private container: HTMLElement;
+  private renderer: Renderer;
   private controlsInteractionEnabled = false;
   private spinAbortController: AbortController | null = null;
 
-  constructor(globeControls: OrbitControls, container: HTMLElement) {
+  private targetCameraView?: CameraView;
+  private isAnimatingCamera: boolean = false;
+  private currentInterpolationFactor: number = 0.1; // Default interpolation factor
+
+  constructor(globeControls: OrbitControls, container: HTMLElement, renderer: Renderer) {
     this.globeControls = globeControls;
     this.container = container;
+    this.renderer = renderer;
 
     // Disable the default controls interaction
     this.updateControlsEnabled(false);
@@ -35,9 +46,51 @@ export class InteractionController {
   public setControlsInteractionEnabled(enabled: boolean): void {
     this.controlsInteractionEnabled = enabled;
     this.updateControlsEnabled(enabled);
+  }
 
-    if (enabled) {
-      this.setAutoSpin(false);
+  public setCameraView(
+    newCameraView: Partial<CameraView>,
+    isAnimated = true,
+    interpolationFactor?: number
+  ) {
+    const currentView = this.renderer.getCameraView();
+
+    if (!currentView) {
+      console.warn('Cannot set camera view, current camera view is undefined.');
+      return;
+    }
+
+    const targetCameraView: CameraView = {
+      ...currentView,
+      ...newCameraView
+    };
+
+    if (targetCameraView === currentView) {
+      return;
+    }
+
+    if (targetCameraView.renderMode !== this.renderer.getRenderMode()) {
+      this.renderer.setRenderMode(targetCameraView.renderMode);
+    }
+
+    if (!isAnimated || targetCameraView.renderMode !== RenderMode.GLOBE) {
+      // Immediately set the camera view if not animated or not in globe mode
+      this.renderer.updateGlobeCamera(targetCameraView);
+      // Stop any ongoing animation and re-enable controls
+      this.isAnimatingCamera = false;
+      this.globeControls.enabled = true;
+      this.renderer.mapControls.enabled = true;
+      return;
+    }
+
+    // Start or update animation
+    this.targetCameraView = targetCameraView;
+    this.isAnimatingCamera = true;
+    this.globeControls.enabled = false; // Disable controls during animation
+    this.renderer.mapControls.enabled = false;
+
+    if (interpolationFactor !== undefined) {
+      this.currentInterpolationFactor = interpolationFactor;
     }
   }
 
@@ -52,5 +105,64 @@ export class InteractionController {
     // Enable or disable the controls by setting the pointer events CSS property
     // If we disable the controls, the Three.js autoRoate does not work
     this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
+  }
+
+  public updateCameraAnimation() {
+    if (
+      this.isAnimatingCamera &&
+      this.renderer.getRenderMode() === RenderMode.GLOBE &&
+      this.targetCameraView
+    ) {
+      const currentView = this.renderer.getCameraView();
+      if (!currentView) {
+        this.isAnimatingCamera = false;
+        this.globeControls.enabled = true;
+        this.renderer.mapControls.enabled = true;
+        return;
+      }
+
+      const interpolationFactor = this.currentInterpolationFactor;
+      const epsilon = 1e-6; // Threshold for "close enough"
+
+      let deltaLng = this.targetCameraView.lng - currentView.lng;
+      if (deltaLng > 180) {
+        deltaLng -= 360;
+      } else if (deltaLng < -180) {
+        deltaLng += 360;
+      }
+      let newLat = lerp(currentView.lat, this.targetCameraView.lat, interpolationFactor);
+      let newLng = lerp(currentView.lng, currentView.lng + deltaLng, interpolationFactor);
+      let newZoom = lerp(currentView.zoom, this.targetCameraView.zoom, interpolationFactor);
+      let newAltitude = lerp(
+        currentView.altitude,
+        this.targetCameraView.altitude,
+        interpolationFactor
+      );
+
+      const interpolatedView: CameraView = {
+        renderMode: this.targetCameraView.renderMode,
+        lat: newLat,
+        lng: newLng,
+        zoom: newZoom,
+        altitude: newAltitude
+      };
+
+      // Check if close enough to target
+      const latDiff = Math.abs(interpolatedView.lat - this.targetCameraView.lat);
+      const lngDiff = Math.abs(interpolatedView.lng - this.targetCameraView.lng);
+      const zoomDiff = Math.abs(interpolatedView.zoom - this.targetCameraView.zoom);
+      const altitudeDiff = Math.abs(interpolatedView.altitude - this.targetCameraView.altitude);
+
+      if (latDiff < epsilon && lngDiff < epsilon && zoomDiff < epsilon && altitudeDiff < epsilon) {
+        // Snap to target and stop animation
+        this.renderer.updateGlobeCamera(this.targetCameraView);
+        this.isAnimatingCamera = false;
+        this.globeControls.enabled = true;
+        this.renderer.mapControls.enabled = true;
+      } else {
+        // Directly update camera position and internal cameraView
+        this.renderer.updateGlobeCamera(interpolatedView);
+      }
+    }
   }
 }

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -2,8 +2,7 @@ import {OrbitControls} from './vendor/orbit-controls.js';
 import {CameraView} from './types/camera-view.js';
 import {RenderMode} from './types/renderer';
 import {Renderer} from './renderer';
-
-const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+import { lerp } from './lib/easing.js';
 
 export class InteractionController {
   private globeControls: OrbitControls;
@@ -93,29 +92,6 @@ export class InteractionController {
     }
   }
 
-  private abortCurrentSpin(): void {
-    if (this.spinAbortController) {
-      this.spinAbortController.abort();
-      this.spinAbortController = null;
-    }
-  }
-
-  private updateControlsEnabled(isEnabled: boolean): void {
-    // Enable or disable the controls by setting the pointer events CSS property
-    // If we disable the controls, the Three.js autoRoate does not work
-    this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
-  }
-
-  private calculateShortestLongitudeDelta(from: number, to: number) {
-    let delta = to - from;
-    if (delta > 180) {
-      delta -= 360;
-    } else if (delta < -180) {
-      delta += 360;
-    }
-    return delta;
-  }
-
   public updateCameraAnimation() {
     if (
       this.isAnimatingCamera &&
@@ -171,5 +147,28 @@ export class InteractionController {
         this.renderer.updateGlobeCamera(interpolatedView);
       }
     }
+  }
+
+  private abortCurrentSpin(): void {
+    if (this.spinAbortController) {
+      this.spinAbortController.abort();
+      this.spinAbortController = null;
+    }
+  }
+
+  private updateControlsEnabled(isEnabled: boolean): void {
+    // Enable or disable the controls by setting the pointer events CSS property
+    // If we disable the controls, the Three.js autoRoate does not work
+    this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
+  }
+
+  private calculateShortestLongitudeDelta(from: number, to: number) {
+    let delta = to - from;
+    if (delta > 180) {
+      delta -= 360;
+    } else if (delta < -180) {
+      delta += 360;
+    }
+    return delta;
   }
 }

--- a/src/renderer/interaction-controller.ts
+++ b/src/renderer/interaction-controller.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import {OrbitControls} from './vendor/orbit-controls.js';
 import {CameraView} from './types/camera-view.js';
 import {RenderMode} from './types/renderer';
@@ -107,6 +106,16 @@ export class InteractionController {
     this.container.style.pointerEvents = isEnabled ? 'auto' : 'none';
   }
 
+  private calculateShortestLongitudeDelta(from: number, to: number) {
+    let delta = to - from;
+    if (delta > 180) {
+      delta -= 360;
+    } else if (delta < -180) {
+      delta += 360;
+    }
+    return delta;
+  }
+
   public updateCameraAnimation() {
     if (
       this.isAnimatingCamera &&
@@ -124,12 +133,10 @@ export class InteractionController {
       const interpolationFactor = this.currentInterpolationFactor;
       const epsilon = 1e-6; // Threshold for "close enough"
 
-      let deltaLng = this.targetCameraView.lng - currentView.lng;
-      if (deltaLng > 180) {
-        deltaLng -= 360;
-      } else if (deltaLng < -180) {
-        deltaLng += 360;
-      }
+      const deltaLng = this.calculateShortestLongitudeDelta(
+        currentView.lng,
+        this.targetCameraView.lng
+      );
       let newLat = lerp(currentView.lat, this.targetCameraView.lat, interpolationFactor);
       let newLng = lerp(currentView.lng, currentView.lng + deltaLng, interpolationFactor);
       let newZoom = lerp(currentView.zoom, this.targetCameraView.zoom, interpolationFactor);

--- a/src/renderer/lib/easing.ts
+++ b/src/renderer/lib/easing.ts
@@ -1,0 +1,2 @@
+// ease in out quad: https://easings.net/#easeInOutQuad
+export const easeInQutQuad = (t: number) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2);

--- a/src/renderer/lib/easing.ts
+++ b/src/renderer/lib/easing.ts
@@ -1,2 +1,1 @@
-// ease in out quad: https://easings.net/#easeInOutQuad
-export const easeInQutQuad = (t: number) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2);
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -343,6 +343,7 @@ export class Renderer extends EventTarget {
 
       if (t >= 1) {
         this.setCameraView(to);
+        const {onAfterFly} = this.flyToAnimation;
         this.flyToAnimation = undefined;
         this.globeControls.enabled = previousGlobeControlsEnabled;
         this.mapControls.enabled = previousMapControlsEnabled;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -346,7 +346,6 @@ export class Renderer extends EventTarget {
 
       if (t >= 1) {
         this.setCameraView(to);
-        const {onAfterFly} = this.flyToAnimation;
         this.flyToAnimation = undefined;
         this.globeControls.enabled = previousGlobeControlsEnabled;
         this.mapControls.enabled = previousMapControlsEnabled;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -6,9 +6,9 @@ import {MapControls} from 'three/examples/jsm/controls/MapControls';
 import {TileManager} from './tile-manager';
 import {MarkerHtml} from './marker-html';
 import {cameraViewToGlobePosition, globePositionToCameraView} from './lib/convert-spaces';
-import {RenderMode, RenderOptions} from './types/renderer';
+import {FlyToAnimation, RenderMode, RenderOptions} from './types/renderer';
 
-import { easeInQutQuad } from './lib/easing.js';
+import {easeInQutQuad} from './lib/easing.js';
 
 import type {RenderTile} from './types/tile';
 import type {CameraView} from './types/camera-view';
@@ -16,7 +16,6 @@ import type {MarkerProps} from './types/marker';
 import {MAP_HEIGHT, MAP_WIDTH} from './config';
 
 import {Atmosphere} from './atmosphere';
-import {easeInQutQuad} from './lib/easing.js';
 
 export class Renderer extends EventTarget {
   readonly container: HTMLElement;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,4 +1,12 @@
-import {Clock, OrthographicCamera, PerspectiveCamera, Scene, Vector2, WebGLRenderer, Vector3} from 'three';
+import {
+  Clock,
+  OrthographicCamera,
+  PerspectiveCamera,
+  Scene,
+  Vector2,
+  WebGLRenderer,
+  Vector3
+} from 'three';
 
 // @ts-ignore
 import {OrbitControls} from './vendor/orbit-controls.js';
@@ -7,8 +15,6 @@ import {TileManager} from './tile-manager';
 import {MarkerHtml} from './marker-html';
 import {cameraViewToGlobePosition, globePositionToCameraView} from './lib/convert-spaces';
 import {RenderMode, RenderOptions} from './types/renderer';
-
-import { lerp } from './lib/easing.js';
 
 import type {RenderTile} from './types/tile';
 import type {CameraView} from './types/camera-view';
@@ -29,7 +35,6 @@ export class Renderer extends EventTarget {
   public mapControls: MapControls;
 
   private tileManager: TileManager;
-  private cameraView?: CameraView;
   private markersById: Record<string, MarkerHtml> = {};
   private renderMode: RenderMode = RenderMode.GLOBE;
 
@@ -135,8 +140,6 @@ export class Renderer extends EventTarget {
     }
     return undefined;
   }
-
-  
 
   setMarkers(markerProps: MarkerProps[]) {
     // remove markers that are no longer needeed
@@ -268,7 +271,6 @@ export class Renderer extends EventTarget {
 
   public updateGlobeCamera(cameraView: CameraView) {
     cameraViewToGlobePosition(cameraView, this.globeCamera.position);
-    this.cameraView = cameraView;
     this.globeCamera.lookAt(0, 0, 0);
   }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,12 +1,4 @@
-import {
-  Clock,
-  OrthographicCamera,
-  PerspectiveCamera,
-  Scene,
-  Vector2,
-  WebGLRenderer,
-  Vector3
-} from 'three';
+import {Clock, OrthographicCamera, PerspectiveCamera, Scene, Vector2, WebGLRenderer, Vector3} from 'three';
 
 // @ts-ignore
 import {OrbitControls} from './vendor/orbit-controls.js';
@@ -16,13 +8,14 @@ import {MarkerHtml} from './marker-html';
 import {cameraViewToGlobePosition, globePositionToCameraView} from './lib/convert-spaces';
 import {RenderMode, RenderOptions} from './types/renderer';
 
+import { lerp } from './lib/easing.js';
+
 import type {RenderTile} from './types/tile';
 import type {CameraView} from './types/camera-view';
 import type {MarkerProps} from './types/marker';
 import {MAP_HEIGHT, MAP_WIDTH} from './config';
 
 import {Atmosphere} from './atmosphere';
-import {WebGlGlobeProps} from '../webgl-globe.js';
 
 export class Renderer extends EventTarget {
   readonly container: HTMLElement;
@@ -333,14 +326,10 @@ export class Renderer extends EventTarget {
       } else if (deltaLng < -180) {
         deltaLng += 360;
       }
-      let newLat =
-        currentView.lat + (this.targetCameraView.lat - currentView.lat) * interpolationFactor;
-      let newLng = currentView.lng + deltaLng * interpolationFactor;
-      let newZoom =
-        currentView.zoom + (this.targetCameraView.zoom - currentView.zoom) * interpolationFactor;
-      let newAltitude =
-        currentView.altitude +
-        (this.targetCameraView.altitude - currentView.altitude) * interpolationFactor;
+      let newLat = lerp(currentView.lat, this.targetCameraView.lat, interpolationFactor);
+      let newLng = lerp(currentView.lng, currentView.lng + deltaLng, interpolationFactor);
+      let newZoom = lerp(currentView.zoom, this.targetCameraView.zoom, interpolationFactor);
+      let newAltitude = lerp(currentView.altitude, this.targetCameraView.altitude, interpolationFactor);
 
       const interpolatedView: CameraView = {
         renderMode: this.targetCameraView.renderMode,

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -169,6 +169,7 @@ export class Renderer extends EventTarget {
     const from = this.getCameraView();
 
     if (!from) {
+      console.warn('Cannot fly to camera view, current camera view is undefined.');
       return;
     }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -8,6 +8,8 @@ import {MarkerHtml} from './marker-html';
 import {cameraViewToGlobePosition, globePositionToCameraView} from './lib/convert-spaces';
 import {RenderMode, RenderOptions} from './types/renderer';
 
+import { easeInQutQuad } from './lib/easing.js';
+
 import type {RenderTile} from './types/tile';
 import type {CameraView} from './types/camera-view';
 import type {MarkerProps} from './types/marker';

--- a/src/renderer/types/renderer.ts
+++ b/src/renderer/types/renderer.ts
@@ -1,7 +1,19 @@
+import {CameraView} from './camera-view';
+
 export const enum RenderMode {
   GLOBE = 'globe',
   MAP = 'map'
 }
+
+export type FlyToAnimation = {
+  from: CameraView;
+  to: CameraView;
+  startTime: number;
+  duration: number;
+  onAfterFly?: () => void;
+  previousGlobeControlsEnabled: boolean;
+  previousMapControlsEnabled: boolean;
+};
 
 export type RenderOptions = Partial<{
   atmosphereEnabled: boolean;

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -95,6 +95,8 @@ export class WebGlGlobe extends EventTarget {
     }
 
     if (props.cameraFlyTo) {
+      // If cameraFlyTo is set, stop any auto-spin and fly to the new position
+      this.stopAutoSpin();
       this.renderer.flyCameraTo({
         renderMode: RenderMode.GLOBE,
         ...props.cameraFlyTo

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -108,9 +108,7 @@ export class WebGlGlobe extends EventTarget {
         duration,
         onAfterFly
       );
-    }
-
-    if (props.cameraView) {
+    } else if (props.cameraView) {
       this.renderer.setCameraView({
         renderMode: RenderMode.GLOBE,
         lat: 0,

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -97,13 +97,16 @@ export class WebGlGlobe extends EventTarget {
     if (props.cameraFlyTo) {
       // If cameraFlyTo is set, stop any auto-spin and fly to the new position
       this.stopAutoSpin();
+
+      const {duration, onAfterFly, ...flyToOptions} = props.cameraFlyTo;
+
       this.renderer.flyCameraTo(
         {
           renderMode: RenderMode.GLOBE,
-          ...props.cameraFlyTo
+          ...flyToOptions,
         },
-        props.cameraFlyTo.duration,
-        props.cameraFlyTo.onAfterFly
+        duration,
+        onAfterFly
       );
     }
 

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -18,6 +18,7 @@ export type WebGlGlobeProps = Partial<{
   layers: LayerProps<any>[];
   renderMode: RenderMode;
   cameraView: Partial<CameraView>;
+  cameraFlyTo: Partial<CameraView>;
   markers: MarkerProps[];
   allowDownsampling: boolean;
   renderOptions: RenderOptions;
@@ -91,6 +92,13 @@ export class WebGlGlobe extends EventTarget {
 
     if (props.layers) {
       this.setLayers(props.layers);
+    }
+
+    if (props.cameraFlyTo) {
+      this.renderer.flyCameraTo({
+        renderMode: RenderMode.GLOBE,
+        ...props.cameraFlyTo
+      });
     }
 
     if (props.cameraView) {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -18,7 +18,7 @@ export type WebGlGlobeProps = Partial<{
   layers: LayerProps<any>[];
   renderMode: RenderMode;
   cameraView: Partial<CameraView>;
-  cameraFlyTo: Partial<CameraView>;
+  cameraFlyTo: Partial<CameraView> & {duration?: number; onAfterFly?: () => void};
   markers: MarkerProps[];
   allowDownsampling: boolean;
   renderOptions: RenderOptions;
@@ -97,10 +97,14 @@ export class WebGlGlobe extends EventTarget {
     if (props.cameraFlyTo) {
       // If cameraFlyTo is set, stop any auto-spin and fly to the new position
       this.stopAutoSpin();
-      this.renderer.flyCameraTo({
-        renderMode: RenderMode.GLOBE,
-        ...props.cameraFlyTo
-      });
+      this.renderer.flyCameraTo(
+        {
+          renderMode: RenderMode.GLOBE,
+          ...props.cameraFlyTo
+        },
+        props.cameraFlyTo.duration,
+        props.cameraFlyTo.onAfterFly
+      );
     }
 
     if (props.cameraView) {

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -17,8 +17,7 @@ const TILESELECTOR_FPS = 15;
 export type WebGlGlobeProps = Partial<{
   layers: LayerProps<any>[];
   renderMode: RenderMode;
-  cameraView: Partial<CameraView>;
-  cameraFlyTo: Partial<CameraView> & {duration?: number; onAfterFly?: () => void};
+  cameraView: Partial<CameraView> & {isAnimated?: boolean; interpolationFactor?: number};
   markers: MarkerProps[];
   allowDownsampling: boolean;
   renderOptions: RenderOptions;
@@ -94,30 +93,9 @@ export class WebGlGlobe extends EventTarget {
       this.setLayers(props.layers);
     }
 
-    if (props.cameraFlyTo) {
-      // If cameraFlyTo is set, stop any auto-spin and fly to the new position
-      this.stopAutoSpin();
-
-      const {duration, onAfterFly, ...flyToOptions} = props.cameraFlyTo;
-
-      this.renderer.flyCameraTo(
-        {
-          renderMode: RenderMode.GLOBE,
-          ...flyToOptions,
-        },
-        duration,
-        onAfterFly
-      );
-    } else if (props.cameraView) {
-      this.renderer.setCameraView({
-        renderMode: RenderMode.GLOBE,
-        lat: 0,
-        lng: 0,
-        zoom: 0,
-        altitude: 0,
-
-        ...props.cameraView
-      });
+    if (props.cameraView) {
+      const {isAnimated, interpolationFactor, ...newCameraView} = props.cameraView;
+      this.renderer.setCameraView(newCameraView, isAnimated, interpolationFactor);
     }
 
     if (props.markers) {
@@ -250,7 +228,7 @@ export class WebGlGlobe extends EventTarget {
     this.resizeObserver.unobserve(this.container);
     this.abortController.abort();
     this.renderer.destroy();
-    this.renderer.getGlobeControls().disconnect()
+    this.renderer.getGlobeControls().disconnect();
     void this.tileSelector.destroy();
   }
 

--- a/src/webgl-globe.ts
+++ b/src/webgl-globe.ts
@@ -75,7 +75,8 @@ export class WebGlGlobe extends EventTarget {
 
     this.interactionController = new InteractionController(
       this.renderer.getGlobeControls(),
-      this.container
+      this.container,
+      this.renderer
     );
 
     this.setProps({...DEFAULT_PROPS, ...props});
@@ -95,7 +96,7 @@ export class WebGlGlobe extends EventTarget {
 
     if (props.cameraView) {
       const {isAnimated, interpolationFactor, ...newCameraView} = props.cameraView;
-      this.renderer.setCameraView(newCameraView, isAnimated, interpolationFactor);
+      this.interactionController.setCameraView(newCameraView, isAnimated, interpolationFactor);
     }
 
     if (props.markers) {
@@ -174,6 +175,7 @@ export class WebGlGlobe extends EventTarget {
     const loop = () => {
       this.tileUpdateRafId = requestAnimationFrame(loop);
       this.updateRenderTiles();
+      this.interactionController.updateCameraAnimation();
     };
 
     this.tileUpdateRafId = requestAnimationFrame(loop);


### PR DESCRIPTION
**Summary**
This PR adds support for an animated `flyCameraTo` method, based on updated requirements from the revised story concept.

**Changes**
Implemented `flyCameraTo` method and exposes it to the user via the `setProps` api
Implement a new example page demonstrating the method

**Context**
The globe is now expected to transition automatically to a give location. This transition should be smoothly animated

**Requirements**
`flyCameraTo` should receive `CameraProps`, a `duration` and way to execute an optional callback after the flyTo has been applied